### PR TITLE
[Contribution] Add new option for custom strike tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ export interface NodeHtmlMarkdownOptions {
   strongDelimiter: string,
 
   /**
+   * Strong delimiter
+   * @default ~~
+   */
+  strikeDelimiter: string,
+
+  /**
    * Supplied elements will be ignored (ignores inner text does not parse children)
    */
   ignore?: string[],

--- a/src/config.ts
+++ b/src/config.ts
@@ -38,6 +38,7 @@ export const defaultOptions: Readonly<NodeHtmlMarkdownOptions> = Object.freeze({
   codeBlockStyle: <'indented' | 'fenced'>'fenced',
   emDelimiter: '_',
   strongDelimiter: '**',
+  strikeDelimiter: '~~',
   maxConsecutiveNewlines: 3,
   /**
    * Character:               Affects:                       Example:
@@ -104,10 +105,10 @@ export const defaultTranslators: TranslatorConfigObject = {
   /* Strikethrough */
   'del,s,strike': {
     spaceIfRepeatingChar: true,
-    postprocess: ({ content }) =>
+    postprocess: ({ content, options: { strikeDelimiter } }) =>
       isWhiteSpaceOnly(content)
       ? PostProcessResult.RemoveNode
-      : tagSurround(content, '~~')
+      : tagSurround(content, strikeDelimiter)
   },
 
   /* Italic / Emphasis */

--- a/src/options.ts
+++ b/src/options.ts
@@ -40,6 +40,12 @@ export interface NodeHtmlMarkdownOptions {
   strongDelimiter: string,
 
   /**
+   * Strong delimiter
+   * @default ~~
+   */
+   strikeDelimiter: string,
+
+  /**
    * Supplied elements will be ignored (ignores inner text does not parse children)
    */
   readonly ignore?: string[],

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -102,6 +102,24 @@ describe(`Options`, () => {
     instance.options.strongDelimiter = originalStrongDelimiter;
   });
 
+
+  test(`strikeDelimiter`, () => {
+    const originalStrikeDelimiter = instance.options.strikeDelimiter;
+    const html = `<strike>some text</strike><s>more text</s><del>one more text</del>`;
+
+    const resDefaultStrikeDelimiter = translate(html);
+    expect(resDefaultStrikeDelimiter).toBe(`~~some text~~ ~~more text~~ ~~one more text~~`);
+
+    instance.options.strikeDelimiter = '~';
+    const resShortStrikeDelimiter = translate(html);
+    expect(resDefaultStrikeDelimiter).toBe(`~some text~ ~more text~ ~one more text~`);
+
+    instance.options.strikeDelimiter =  '+++';
+    const resWideStrikeDelimiter = translate(html);
+    expect(resDefaultStrikeDelimiter).toBe(`+++some text+++ +++more text+++ +++one more text+++`);
+    instance.options.strikeDelimiter = originalStrikeDelimiter;
+  });
+
   test(`ignore`, () => {
     const strongEmHTML = `<strong>some text</strong><em>more text</em>`;
 

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -112,11 +112,11 @@ describe(`Options`, () => {
 
     instance.options.strikeDelimiter = '~';
     const resShortStrikeDelimiter = translate(html);
-    expect(resDefaultStrikeDelimiter).toBe(`~some text~ ~more text~ ~one more text~`);
+    expect(resShortStrikeDelimiter).toBe(`~some text~ ~more text~ ~one more text~`);
 
     instance.options.strikeDelimiter =  '+++';
     const resWideStrikeDelimiter = translate(html);
-    expect(resDefaultStrikeDelimiter).toBe(`+++some text+++ +++more text+++ +++one more text+++`);
+    expect(resWideStrikeDelimiter).toBe(`+++some text+++ +++more text+++ +++one more text+++`);
     instance.options.strikeDelimiter = originalStrikeDelimiter;
   });
 

--- a/test/special-cases.test.ts
+++ b/test/special-cases.test.ts
@@ -16,7 +16,7 @@ const getDelims = (instance: NodeHtmlMarkdown) => Object.fromEntries(textFormatT
       case 'del':
       case 's':
       case 'strike':
-        return '~~';
+        return instance.options.strikeDelimiter;
       case 'em':
       case 'i':
         return instance.options.emDelimiter;


### PR DESCRIPTION
@nonara , thank you for maintaining the [node-html-markdown](https://github.com/crosstype/node-html-markdown), it is saving lots of time.

I did a customisation for a use case I have converting HTML to "Markdown" for Slack ("mrkdwn") and I have one use case for the ~~strike~~ tag. For example, for Slack, it uses just one `~` instead of `~~`.

Here a pull request to improve the library and allow to set a custom strike delimiter, similar to what you already uses for strong/bold.