### PR TITLE
Make inline links optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,18 @@ export interface NodeHtmlMarkdownOptions {
    * [2]: /url2
    */
   useLinkReferenceDefinitions?: boolean
+
+  /**
+   * Wrap URL text in < > instead of []() syntax.
+   * 
+   * @example
+   * The input <a href="https://google.com">https://google.com</a>
+   * becomes <https://google.com>
+   * instead of [https://google.com](https://google.com)
+   * 
+   * @default true
+   */
+  useAngleLinks?: boolean
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ export interface NodeHtmlMarkdownOptions {
    * 
    * @default true
    */
-  useAngleLinks?: boolean
+  useInlineLinks?: boolean
 }
 ```
 

--- a/benchmark/yarn.lock
+++ b/benchmark/yarn.lock
@@ -12,61 +12,68 @@ boolbase@^1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-css-select@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
-  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+css-select@^4.2.1:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.3.0.tgz#db7129b2846662fd8628cfc496abb2b59e41529b"
+  integrity sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==
   dependencies:
     boolbase "^1.0.0"
-    css-what "^6.1.0"
-    domhandler "^5.0.2"
-    domutils "^3.0.1"
+    css-what "^6.0.1"
+    domhandler "^4.3.1"
+    domutils "^2.8.0"
     nth-check "^2.0.1"
 
-css-what@^6.1.0:
+css-what@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
   integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
-dom-serializer@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
-  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+dom-serializer@^1.0.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
+  integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
   dependencies:
-    domelementtype "^2.3.0"
-    domhandler "^5.0.2"
-    entities "^4.2.0"
+    domelementtype "^2.0.1"
+    domhandler "^4.2.0"
+    entities "^2.0.0"
 
-domelementtype@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
-  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+domelementtype@^2.0.1, domelementtype@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
+  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
 
-domhandler@^5.0.1, domhandler@^5.0.2:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
-  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+domhandler@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.2.0.tgz#f9768a5f034be60a89a27c2e4d0f74eba0d8b059"
+  integrity sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==
   dependencies:
-    domelementtype "^2.3.0"
+    domelementtype "^2.2.0"
+
+domhandler@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.1.tgz#8d792033416f59d68bc03a5aa7b018c1ca89279c"
+  integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
+  dependencies:
+    domelementtype "^2.2.0"
 
 domino@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/domino/-/domino-2.1.6.tgz#fe4ace4310526e5e7b9d12c7de01b7f485a57ffe"
   integrity sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ==
 
-domutils@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.0.1.tgz#696b3875238338cb186b6c0612bd4901c89a4f1c"
-  integrity sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==
+domutils@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
+  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
   dependencies:
-    dom-serializer "^2.0.0"
-    domelementtype "^2.3.0"
-    domhandler "^5.0.1"
+    dom-serializer "^1.0.1"
+    domelementtype "^2.2.0"
+    domhandler "^4.2.0"
 
-entities@^4.2.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
-  integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
+entities@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
 he@1.2.0:
   version "1.2.0"
@@ -77,12 +84,12 @@ he@1.2.0:
   version "0.0.0"
   uid ""
 
-node-html-parser@^6.1.1:
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-6.1.4.tgz#763cd362497e427d51fc73dda3dcd8ac52ba85a3"
-  integrity sha512-3muP9Uy/Pz7bQa9TNYVQzWJhNZMqyCx7xJle8kz2/y1UgzAUyXXShc1IcPaJy6u07CE3K5rQcRwlvHzmlySRjg==
+node-html-parser@^5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-5.3.3.tgz#2845704f3a7331a610e0e551bf5fa02b266341b6"
+  integrity sha512-ncg1033CaX9UexbyA7e1N0aAoAYRDiV8jkTvzEnfd1GDvzFdrsXLzR4p4ik8mwLgnaKP/jyUFWDy9q3jvRT2Jw==
   dependencies:
-    css-select "^5.1.0"
+    css-select "^4.2.1"
     he "1.2.0"
 
 nth-check@^2.0.1:

--- a/benchmark/yarn.lock
+++ b/benchmark/yarn.lock
@@ -12,68 +12,61 @@ boolbase@^1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
-css-select@^4.2.1:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.3.0.tgz#db7129b2846662fd8628cfc496abb2b59e41529b"
-  integrity sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
   dependencies:
     boolbase "^1.0.0"
-    css-what "^6.0.1"
-    domhandler "^4.3.1"
-    domutils "^2.8.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
     nth-check "^2.0.1"
 
-css-what@^6.0.1:
+css-what@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
   integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
-dom-serializer@^1.0.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-1.3.2.tgz#6206437d32ceefaec7161803230c7a20bc1b4d91"
-  integrity sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
   dependencies:
-    domelementtype "^2.0.1"
-    domhandler "^4.2.0"
-    entities "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
 
-domelementtype@^2.0.1, domelementtype@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.2.0.tgz#9a0b6c2782ed6a1c7323d42267183df9bd8b1d57"
-  integrity sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
 
-domhandler@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.2.0.tgz#f9768a5f034be60a89a27c2e4d0f74eba0d8b059"
-  integrity sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==
+domhandler@^5.0.1, domhandler@^5.0.2:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
   dependencies:
-    domelementtype "^2.2.0"
-
-domhandler@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.1.tgz#8d792033416f59d68bc03a5aa7b018c1ca89279c"
-  integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
-  dependencies:
-    domelementtype "^2.2.0"
+    domelementtype "^2.3.0"
 
 domino@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/domino/-/domino-2.1.6.tgz#fe4ace4310526e5e7b9d12c7de01b7f485a57ffe"
   integrity sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ==
 
-domutils@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.8.0.tgz#4437def5db6e2d1f5d6ee859bd95ca7d02048135"
-  integrity sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==
+domutils@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.0.1.tgz#696b3875238338cb186b6c0612bd4901c89a4f1c"
+  integrity sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==
   dependencies:
-    dom-serializer "^1.0.1"
-    domelementtype "^2.2.0"
-    domhandler "^4.2.0"
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.1"
 
-entities@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
-  integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+entities@^4.2.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
+  integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
 
 he@1.2.0:
   version "1.2.0"
@@ -84,12 +77,12 @@ he@1.2.0:
   version "0.0.0"
   uid ""
 
-node-html-parser@^5.3.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-5.3.3.tgz#2845704f3a7331a610e0e551bf5fa02b266341b6"
-  integrity sha512-ncg1033CaX9UexbyA7e1N0aAoAYRDiV8jkTvzEnfd1GDvzFdrsXLzR4p4ik8mwLgnaKP/jyUFWDy9q3jvRT2Jw==
+node-html-parser@^6.1.1:
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-6.1.4.tgz#763cd362497e427d51fc73dda3dcd8ac52ba85a3"
+  integrity sha512-3muP9Uy/Pz7bQa9TNYVQzWJhNZMqyCx7xJle8kz2/y1UgzAUyXXShc1IcPaJy6u07CE3K5rQcRwlvHzmlySRjg==
   dependencies:
-    css-select "^4.2.1"
+    css-select "^5.1.0"
     he "1.2.0"
 
 nth-check@^2.0.1:

--- a/src/config.ts
+++ b/src/config.ts
@@ -68,7 +68,9 @@ export const defaultOptions: Readonly<NodeHtmlMarkdownOptions> = Object.freeze({
   lineStartEscape: [
     /^(\s*?)((?:\+\s)|(?:[=>-])|(?:#{1,6}\s))|(?:(\d+)(\.\s))/gm,
     '$1$3\\$2$4'
-  ] as const
+  ] as const,
+
+  useAngleLinks: true
 });
 
 // endregion
@@ -268,7 +270,7 @@ export const defaultTranslators: TranslatorConfigObject = {
 
     // Inline link, when possible
     // See: https://github.com/crosstype/node-html-markdown/issues/17
-    if (node.textContent === href) return { content: `<${encodedHref}>` };
+    if (node.textContent === href && options.useAngleLinks) return { content: `<${encodedHref}>` };
 
     return {
       postprocess: ({ content }) => content.replace(/(?:\r?\n)+/g, ' '),

--- a/src/config.ts
+++ b/src/config.ts
@@ -70,7 +70,7 @@ export const defaultOptions: Readonly<NodeHtmlMarkdownOptions> = Object.freeze({
     '$1$3\\$2$4'
   ] as const,
 
-  useAngleLinks: true
+  useInlineLinks: true
 });
 
 // endregion
@@ -270,7 +270,7 @@ export const defaultTranslators: TranslatorConfigObject = {
 
     // Inline link, when possible
     // See: https://github.com/crosstype/node-html-markdown/issues/17
-    if (node.textContent === href && options.useAngleLinks) return { content: `<${encodedHref}>` };
+    if (node.textContent === href && options.useInlineLinks) return { content: `<${encodedHref}>` };
 
     return {
       postprocess: ({ content }) => content.replace(/(?:\r?\n)+/g, ' '),

--- a/src/options.ts
+++ b/src/options.ts
@@ -99,6 +99,18 @@ export interface NodeHtmlMarkdownOptions {
    * [2]: /url2
    */
   useLinkReferenceDefinitions?: boolean
+
+  /**
+   * Wrap URL text in < > instead of []() syntax.
+   *
+   * @example
+   * The input <a href="https://google.com">https://google.com</a>
+   * becomes <https://google.com>
+   * instead of [https://google.com](https://google.com)
+   *
+   * @default true
+   */
+  useAngleLinks?: boolean
 }
 
 // endregion

--- a/src/options.ts
+++ b/src/options.ts
@@ -110,7 +110,7 @@ export interface NodeHtmlMarkdownOptions {
    *
    * @default true
    */
-  useAngleLinks?: boolean
+  useInlineLinks?: boolean
 }
 
 // endregion

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -1,7 +1,6 @@
 // noinspection RegExpUnnecessaryNonCapturingGroup,HtmlUnknownTarget
 
-import { NodeHtmlMarkdown } from '../src';
-
+import { NodeHtmlMarkdown } from "../src";
 
 /* ****************************************************************************************************************** *
  * Options Tests
@@ -19,16 +18,16 @@ describe(`Options`, () => {
     const str = `* test  \n\n1. test\n\\Test`;
     const html = `<pre><code class="language-fortran">${str}</code></pre>`;
 
-   const resDefaultFence = translate(html);
-    expect(resDefaultFence).toBe('```fortran\n' + str + '\n```');
+    const resDefaultFence = translate(html);
+    expect(resDefaultFence).toBe("```fortran\n" + str + "\n```");
 
     instance.options.codeFence = `+++++`;
     const resFencePlus = translate(html);
-    expect(resFencePlus).toBe('+++++fortran\n' + str + '\n+++++');
+    expect(resFencePlus).toBe("+++++fortran\n" + str + "\n+++++");
 
     instance.options.codeFence = `?`;
     const resFence1Char = translate(html);
-    expect(resFence1Char).toBe('?fortran\n' + str + '\n?');
+    expect(resFence1Char).toBe("?fortran\n" + str + "\n?");
 
     instance.options.codeFence = originalCodeFence;
   });
@@ -41,12 +40,12 @@ describe(`Options`, () => {
     expect(resDefaultMarker).toBe(`* item1
 * item2`);
 
-    instance.options.bulletMarker = '-';
+    instance.options.bulletMarker = "-";
     const resDashMarker = translate(html);
     expect(resDashMarker).toBe(`- item1
 - item2`);
 
-    instance.options.bulletMarker = '<->';
+    instance.options.bulletMarker = "<->";
     const resWideMarker = translate(html);
     expect(resWideMarker).toBe(`<-> item1
 <-> item2`);
@@ -57,13 +56,13 @@ describe(`Options`, () => {
     const originalCodeFence = instance.options.codeBlockStyle;
     const html = `<pre><code>line1\nline2</code></pre>`;
 
-    instance.options.codeBlockStyle = 'fenced';
+    instance.options.codeBlockStyle = "fenced";
     const resFenced = translate(html);
-    expect(resFenced).toBe('```\nline1\nline2\n```');
+    expect(resFenced).toBe("```\nline1\nline2\n```");
 
-    instance.options.codeBlockStyle = 'indented';
+    instance.options.codeBlockStyle = "indented";
     const resIndented = translate(html);
-    expect(resIndented).toBe('line1\nline2'.replace(/^/gm, '    '));
+    expect(resIndented).toBe("line1\nline2".replace(/^/gm, "    "));
 
     instance.options.codeFence = originalCodeFence;
   });
@@ -75,11 +74,11 @@ describe(`Options`, () => {
     const resDefaultEmDelimiter = translate(html);
     expect(resDefaultEmDelimiter).toBe(`_some text_ _more text_`);
 
-    instance.options.emDelimiter = '|';
+    instance.options.emDelimiter = "|";
     const resShortEmDelimiter = translate(`<em>some text</em><em>more text</em>`);
     expect(resShortEmDelimiter).toBe(`|some text| |more text|`);
 
-    instance.options.emDelimiter = '+++';
+    instance.options.emDelimiter = "+++";
     const resWideEmDelimiter = translate(`<em>some text</em><em>more text</em>`);
     expect(resWideEmDelimiter).toBe(`+++some text+++ +++more text+++`);
     instance.options.emDelimiter = originalEmDelimiter;
@@ -92,16 +91,15 @@ describe(`Options`, () => {
     const resDefaultStrongDelimiter = translate(html);
     expect(resDefaultStrongDelimiter).toBe(`**some text** **more text**`);
 
-    instance.options.strongDelimiter = '|';
+    instance.options.strongDelimiter = "|";
     const resShortStrongDelimiter = translate(html);
     expect(resShortStrongDelimiter).toBe(`|some text| |more text|`);
 
-    instance.options.strongDelimiter =  '+++';
+    instance.options.strongDelimiter = "+++";
     const resWideStrongDelimiter = translate(html);
     expect(resWideStrongDelimiter).toBe(`+++some text+++ +++more text+++`);
     instance.options.strongDelimiter = originalStrongDelimiter;
   });
-
 
   test(`strikeDelimiter`, () => {
     const originalStrikeDelimiter = instance.options.strikeDelimiter;
@@ -110,11 +108,11 @@ describe(`Options`, () => {
     const resDefaultStrikeDelimiter = translate(html);
     expect(resDefaultStrikeDelimiter).toBe(`~~some text~~ ~~more text~~ ~~one more text~~`);
 
-    instance.options.strikeDelimiter = '~';
+    instance.options.strikeDelimiter = "~";
     const resShortStrikeDelimiter = translate(html);
     expect(resShortStrikeDelimiter).toBe(`~some text~ ~more text~ ~one more text~`);
 
-    instance.options.strikeDelimiter =  '+++';
+    instance.options.strikeDelimiter = "+++";
     const resWideStrikeDelimiter = translate(html);
     expect(resWideStrikeDelimiter).toBe(`+++some text+++ +++more text+++ +++one more text+++`);
     instance.options.strikeDelimiter = originalStrikeDelimiter;
@@ -124,25 +122,25 @@ describe(`Options`, () => {
     const strongEmHTML = `<strong>some text</strong><em>more text</em>`;
 
     const instanceIgnore = new NodeHtmlMarkdown({
-      ignore: ['STRONG']
+      ignore: ["STRONG"],
     });
     const resNoStrong = instanceIgnore.translate(strongEmHTML);
     expect(resNoStrong).toBe(`_more text_`);
 
     const instanceIgnoreEm = new NodeHtmlMarkdown({
-      ignore: ['EM']
+      ignore: ["EM"],
     });
     const resNoEm = instanceIgnoreEm.translate(strongEmHTML);
     expect(resNoEm).toBe(`**some text**`);
 
     const instanceIgnoreBoth = new NodeHtmlMarkdown({
-      ignore: ['EM', 'STRONG']
+      ignore: ["EM", "STRONG"],
     });
     const resNoEmStrong = instanceIgnoreBoth.translate(strongEmHTML);
     expect(resNoEmStrong).toBe(``);
 
     const instanceIgnoreMiss = new NodeHtmlMarkdown({
-      ignore: ['UL', 'H1']
+      ignore: ["UL", "H1"],
     });
     const resWithAll = instanceIgnoreMiss.translate(strongEmHTML);
     expect(resWithAll).toBe(`**some text**_more text_`);
@@ -151,7 +149,7 @@ describe(`Options`, () => {
   test(`blockElements`, () => {
     const html = `<em>x</em><strong>yyy</strong><em>x</em><span>text</span>`;
     const instanceStrongBlock = new NodeHtmlMarkdown({
-      blockElements: ['STRONG']
+      blockElements: ["STRONG"],
     });
     const resStrongBlock = instanceStrongBlock.translate(html);
     expect(resStrongBlock).toBe(`_x_
@@ -161,7 +159,7 @@ describe(`Options`, () => {
 _x_text`);
 
     const instanceEmBlock = new NodeHtmlMarkdown({
-      blockElements: ['EM']
+      blockElements: ["EM"],
     });
     const resEmBlock = instanceEmBlock.translate(html);
     expect(resEmBlock).toBe(`_x_
@@ -175,18 +173,18 @@ text`);
 
   test(`maxConsecutiveNewlines`, () => {
     const originalMaxConsecutiveNewlines = instance.options.maxConsecutiveNewlines;
-    const html = `<b>text</b>${'<br/>'.repeat(10)}<em>something</em>`;
+    const html = `<b>text</b>${"<br/>".repeat(10)}<em>something</em>`;
 
     const resDefaultMaxNewLines = translate(html);
-    expect(resDefaultMaxNewLines).toBe(`**text**${'  \n'.repeat(3)}_something_`);
+    expect(resDefaultMaxNewLines).toBe(`**text**${"  \n".repeat(3)}_something_`);
 
     instance.options.maxConsecutiveNewlines = 5;
     const res5MaxNewLines = translate(html);
-    expect(res5MaxNewLines).toBe(`**text**${'  \n'.repeat(5)}_something_`);
+    expect(res5MaxNewLines).toBe(`**text**${"  \n".repeat(5)}_something_`);
 
     instance.options.maxConsecutiveNewlines = 10;
     const res10MaxNewLines = translate(html);
-    expect(res10MaxNewLines).toBe(`**text**${'  \n'.repeat(10)}_something_`);
+    expect(res10MaxNewLines).toBe(`**text**${"  \n".repeat(10)}_something_`);
 
     instance.options.maxConsecutiveNewlines = originalMaxConsecutiveNewlines;
   });
@@ -201,13 +199,13 @@ text`);
     expect(resEscapedQuote).toBe("text  \n\\> text  \n\\> more text");
 
     // No escape for +
-    instance.options.lineStartEscape = [/^(\s*?)((?:[=>-])|(?:#{1,6}\s))|(?:(\d+)(\.\s))/gm, '$1$3\\$2$4'];
+    instance.options.lineStartEscape = [/^(\s*?)((?:[=>-])|(?:#{1,6}\s))|(?:(\d+)(\.\s))/gm, "$1$3\\$2$4"];
 
     const resNotEscapedPlus = translate(`<p>text<br>+ text<br>+ more text</p>`);
     expect(resNotEscapedPlus).toBe("text  \n+ text  \n+ more text");
 
     // No escape also for >
-    instance.options.lineStartEscape = [/^(\s*?)((?:#{1,6}\s))|(?:(\d+)(\.\s))/gm, '$1$3\\$2$4'];
+    instance.options.lineStartEscape = [/^(\s*?)((?:#{1,6}\s))|(?:(\d+)(\.\s))/gm, "$1$3\\$2$4"];
 
     const resNotEscapedQuote = translate(`<p>text<br>> text<br>> more text</p>`);
     expect(resNotEscapedQuote).toBe("text  \n> text  \n> more text");
@@ -222,7 +220,7 @@ text`);
     expect(resEscapedStar).toBe("**text\\*\\*text**");
 
     // No escape for star
-    instance.options.globalEscape = [ /[_~\[\]]/gm, '\\$&' ];
+    instance.options.globalEscape = [/[_~\[\]]/gm, "\\$&"];
 
     const resNotEscapedStar = translate(`<i>text**text</i>`);
     expect(resNotEscapedStar).toBe("_text**text_");
@@ -231,7 +229,7 @@ text`);
     expect(resEscapedBrackets).toBe("# title \\[more words\\]");
 
     // No escape also for brackets
-    instance.options.globalEscape = [ /[_~]/gm, '\\$&' ];
+    instance.options.globalEscape = [/[_~]/gm, "\\$&"];
     const resNotEscapedBrackets = translate(`<h1>title [more words]</h1>`);
     expect(resNotEscapedBrackets).toBe("# title [more words]");
 
@@ -242,11 +240,11 @@ text`);
     const originalReplace = instance.options.textReplace;
 
     instance.options.textReplace = [[/abc/g, "xyz"]];
-    const replaced = translate('<h1>hello abc</h1>');
+    const replaced = translate("<h1>hello abc</h1>");
     expect(replaced).toBe(`# hello xyz`);
 
     instance.options.textReplace = [[/hello/g, "X"]];
-    const replaced2 = translate('<h1>hello abc</h1>');
+    const replaced2 = translate("<h1>hello abc</h1>");
     expect(replaced2).toBe(`# X abc`);
 
     instance.options.textReplace = originalReplace;
@@ -271,7 +269,7 @@ text`);
   test(`useLinkReferenceDefinitions`, () => {
     const originalUseLinkReferenceDefinitions = instance.options.useLinkReferenceDefinitions;
 
-    const url = 'http://www.github.com/crosstype';
+    const url = "http://www.github.com/crosstype";
     const html = `Hello:&nbsp;
         <a href="${url}">a<br><br>b<strong>c</strong></a>
         <a>a<strong>b</strong></a> <!-- This node is treated as text due to no href -->
@@ -282,9 +280,7 @@ text`);
 
     instance.options.useLinkReferenceDefinitions = false;
     let res = translate(html);
-    expect(res).toBe(
-      `Hello: [a b**c**](${url}) a**b** [link2](${url}/other) [repeat link](${url}) <${url}> Goodbye!`
-    );
+    expect(res).toBe(`Hello: [a b**c**](${url}) a**b** [link2](${url}/other) [repeat link](${url}) <${url}> Goodbye!`);
 
     instance.options.useLinkReferenceDefinitions = true;
     res = translate(html);
@@ -293,5 +289,54 @@ text`);
     );
 
     instance.options.useLinkReferenceDefinitions = originalUseLinkReferenceDefinitions;
+  });
+
+  test(`useLinkReferenceDefinitions`, () => {
+    const originalUseLinkReferenceDefinitions = instance.options.useLinkReferenceDefinitions;
+
+    const url = "http://www.github.com/crosstype";
+    const html = `Hello:&nbsp;
+        <a href="${url}">a<br><br>b<strong>c</strong></a>
+        <a>a<strong>b</strong></a> <!-- This node is treated as text due to no href -->
+        <a href="${url}/other">link2</a>
+        <a href="${url}">repeat link</a>
+        <a href="${url}">${url}</a><!-- inline link -->&nbsp;Goodbye!
+    `;
+
+    instance.options.useLinkReferenceDefinitions = false;
+    let res = translate(html);
+    expect(res).toBe(`Hello: [a b**c**](${url}) a**b** [link2](${url}/other) [repeat link](${url}) <${url}> Goodbye!`);
+
+    instance.options.useLinkReferenceDefinitions = true;
+    res = translate(html);
+    expect(res).toBe(
+      `Hello: [a b**c**][1] a**b** [link2][2] [repeat link][1] <${url}> Goodbye!\n\n[1]: ${url}\n[2]: ${url}/other`
+    );
+
+    instance.options.useLinkReferenceDefinitions = originalUseLinkReferenceDefinitions;
+  });
+
+  test(`useAngleLinks`, () => {
+    const originalUseAngleLinksDefinitions = instance.options.useAngleLinks;
+
+    const url = "http://www.github.com/crosstype";
+    const html = `Hello:&nbsp;
+        <a href="${url}">${url}</a> <!-- inline link -->&nbsp;
+        <a>a<strong>b</strong></a> <!-- This node is treated as text due to no href -->
+        <a href="${url}/other">link2</a>
+        <a href="${url}">repeat link</a> Goodbye!
+    `;
+
+    instance.options.useAngleLinks = false;
+    let res = translate(html);
+    expect(res).toBe(`Hello: [${url}](${url}) a**b** [link2](${url}/other) [repeat link](${url}) Goodbye!`);
+
+    instance.options.useAngleLinks = true;
+    res = translate(html);
+    expect(res).toBe(
+      `Hello: <${url}> a**b** [link2](${url}/other) [repeat link](${url}) Goodbye!`
+    );
+
+    instance.options.useLinkReferenceDefinitions = originalUseAngleLinksDefinitions;
   });
 });

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -316,8 +316,8 @@ text`);
     instance.options.useLinkReferenceDefinitions = originalUseLinkReferenceDefinitions;
   });
 
-  test(`useAngleLinks`, () => {
-    const originalUseAngleLinksDefinitions = instance.options.useAngleLinks;
+  test(`useInlineLinks`, () => {
+    const originalUseInlineLinksDefinitions = instance.options.useInlineLinks;
 
     const url = "http://www.github.com/crosstype";
     const html = `Hello:&nbsp;
@@ -327,16 +327,16 @@ text`);
         <a href="${url}">repeat link</a> Goodbye!
     `;
 
-    instance.options.useAngleLinks = false;
+    instance.options.useInlineLinks = false;
     let res = translate(html);
     expect(res).toBe(`Hello: [${url}](${url}) a**b** [link2](${url}/other) [repeat link](${url}) Goodbye!`);
 
-    instance.options.useAngleLinks = true;
+    instance.options.useInlineLinks = true;
     res = translate(html);
     expect(res).toBe(
       `Hello: <${url}> a**b** [link2](${url}/other) [repeat link](${url}) Goodbye!`
     );
 
-    instance.options.useLinkReferenceDefinitions = originalUseAngleLinksDefinitions;
+    instance.options.useLinkReferenceDefinitions = originalUseInlineLinksDefinitions;
   });
 });

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -1,6 +1,7 @@
 // noinspection RegExpUnnecessaryNonCapturingGroup,HtmlUnknownTarget
 
-import { NodeHtmlMarkdown } from "../src";
+import { NodeHtmlMarkdown } from '../src';
+
 
 /* ****************************************************************************************************************** *
  * Options Tests
@@ -18,16 +19,16 @@ describe(`Options`, () => {
     const str = `* test  \n\n1. test\n\\Test`;
     const html = `<pre><code class="language-fortran">${str}</code></pre>`;
 
-    const resDefaultFence = translate(html);
-    expect(resDefaultFence).toBe("```fortran\n" + str + "\n```");
+   const resDefaultFence = translate(html);
+    expect(resDefaultFence).toBe('```fortran\n' + str + '\n```');
 
     instance.options.codeFence = `+++++`;
     const resFencePlus = translate(html);
-    expect(resFencePlus).toBe("+++++fortran\n" + str + "\n+++++");
+    expect(resFencePlus).toBe('+++++fortran\n' + str + '\n+++++');
 
     instance.options.codeFence = `?`;
     const resFence1Char = translate(html);
-    expect(resFence1Char).toBe("?fortran\n" + str + "\n?");
+    expect(resFence1Char).toBe('?fortran\n' + str + '\n?');
 
     instance.options.codeFence = originalCodeFence;
   });
@@ -40,12 +41,12 @@ describe(`Options`, () => {
     expect(resDefaultMarker).toBe(`* item1
 * item2`);
 
-    instance.options.bulletMarker = "-";
+    instance.options.bulletMarker = '-';
     const resDashMarker = translate(html);
     expect(resDashMarker).toBe(`- item1
 - item2`);
 
-    instance.options.bulletMarker = "<->";
+    instance.options.bulletMarker = '<->';
     const resWideMarker = translate(html);
     expect(resWideMarker).toBe(`<-> item1
 <-> item2`);
@@ -56,13 +57,13 @@ describe(`Options`, () => {
     const originalCodeFence = instance.options.codeBlockStyle;
     const html = `<pre><code>line1\nline2</code></pre>`;
 
-    instance.options.codeBlockStyle = "fenced";
+    instance.options.codeBlockStyle = 'fenced';
     const resFenced = translate(html);
-    expect(resFenced).toBe("```\nline1\nline2\n```");
+    expect(resFenced).toBe('```\nline1\nline2\n```');
 
-    instance.options.codeBlockStyle = "indented";
+    instance.options.codeBlockStyle = 'indented';
     const resIndented = translate(html);
-    expect(resIndented).toBe("line1\nline2".replace(/^/gm, "    "));
+    expect(resIndented).toBe('line1\nline2'.replace(/^/gm, '    '));
 
     instance.options.codeFence = originalCodeFence;
   });
@@ -74,11 +75,11 @@ describe(`Options`, () => {
     const resDefaultEmDelimiter = translate(html);
     expect(resDefaultEmDelimiter).toBe(`_some text_ _more text_`);
 
-    instance.options.emDelimiter = "|";
+    instance.options.emDelimiter = '|';
     const resShortEmDelimiter = translate(`<em>some text</em><em>more text</em>`);
     expect(resShortEmDelimiter).toBe(`|some text| |more text|`);
 
-    instance.options.emDelimiter = "+++";
+    instance.options.emDelimiter = '+++';
     const resWideEmDelimiter = translate(`<em>some text</em><em>more text</em>`);
     expect(resWideEmDelimiter).toBe(`+++some text+++ +++more text+++`);
     instance.options.emDelimiter = originalEmDelimiter;
@@ -91,15 +92,16 @@ describe(`Options`, () => {
     const resDefaultStrongDelimiter = translate(html);
     expect(resDefaultStrongDelimiter).toBe(`**some text** **more text**`);
 
-    instance.options.strongDelimiter = "|";
+    instance.options.strongDelimiter = '|';
     const resShortStrongDelimiter = translate(html);
     expect(resShortStrongDelimiter).toBe(`|some text| |more text|`);
 
-    instance.options.strongDelimiter = "+++";
+    instance.options.strongDelimiter =  '+++';
     const resWideStrongDelimiter = translate(html);
     expect(resWideStrongDelimiter).toBe(`+++some text+++ +++more text+++`);
     instance.options.strongDelimiter = originalStrongDelimiter;
   });
+
 
   test(`strikeDelimiter`, () => {
     const originalStrikeDelimiter = instance.options.strikeDelimiter;
@@ -108,11 +110,11 @@ describe(`Options`, () => {
     const resDefaultStrikeDelimiter = translate(html);
     expect(resDefaultStrikeDelimiter).toBe(`~~some text~~ ~~more text~~ ~~one more text~~`);
 
-    instance.options.strikeDelimiter = "~";
+    instance.options.strikeDelimiter = '~';
     const resShortStrikeDelimiter = translate(html);
     expect(resShortStrikeDelimiter).toBe(`~some text~ ~more text~ ~one more text~`);
 
-    instance.options.strikeDelimiter = "+++";
+    instance.options.strikeDelimiter =  '+++';
     const resWideStrikeDelimiter = translate(html);
     expect(resWideStrikeDelimiter).toBe(`+++some text+++ +++more text+++ +++one more text+++`);
     instance.options.strikeDelimiter = originalStrikeDelimiter;
@@ -122,25 +124,25 @@ describe(`Options`, () => {
     const strongEmHTML = `<strong>some text</strong><em>more text</em>`;
 
     const instanceIgnore = new NodeHtmlMarkdown({
-      ignore: ["STRONG"],
+      ignore: ['STRONG']
     });
     const resNoStrong = instanceIgnore.translate(strongEmHTML);
     expect(resNoStrong).toBe(`_more text_`);
 
     const instanceIgnoreEm = new NodeHtmlMarkdown({
-      ignore: ["EM"],
+      ignore: ['EM']
     });
     const resNoEm = instanceIgnoreEm.translate(strongEmHTML);
     expect(resNoEm).toBe(`**some text**`);
 
     const instanceIgnoreBoth = new NodeHtmlMarkdown({
-      ignore: ["EM", "STRONG"],
+      ignore: ['EM', 'STRONG']
     });
     const resNoEmStrong = instanceIgnoreBoth.translate(strongEmHTML);
     expect(resNoEmStrong).toBe(``);
 
     const instanceIgnoreMiss = new NodeHtmlMarkdown({
-      ignore: ["UL", "H1"],
+      ignore: ['UL', 'H1']
     });
     const resWithAll = instanceIgnoreMiss.translate(strongEmHTML);
     expect(resWithAll).toBe(`**some text**_more text_`);
@@ -149,7 +151,7 @@ describe(`Options`, () => {
   test(`blockElements`, () => {
     const html = `<em>x</em><strong>yyy</strong><em>x</em><span>text</span>`;
     const instanceStrongBlock = new NodeHtmlMarkdown({
-      blockElements: ["STRONG"],
+      blockElements: ['STRONG']
     });
     const resStrongBlock = instanceStrongBlock.translate(html);
     expect(resStrongBlock).toBe(`_x_
@@ -159,7 +161,7 @@ describe(`Options`, () => {
 _x_text`);
 
     const instanceEmBlock = new NodeHtmlMarkdown({
-      blockElements: ["EM"],
+      blockElements: ['EM']
     });
     const resEmBlock = instanceEmBlock.translate(html);
     expect(resEmBlock).toBe(`_x_
@@ -173,18 +175,18 @@ text`);
 
   test(`maxConsecutiveNewlines`, () => {
     const originalMaxConsecutiveNewlines = instance.options.maxConsecutiveNewlines;
-    const html = `<b>text</b>${"<br/>".repeat(10)}<em>something</em>`;
+    const html = `<b>text</b>${'<br/>'.repeat(10)}<em>something</em>`;
 
     const resDefaultMaxNewLines = translate(html);
-    expect(resDefaultMaxNewLines).toBe(`**text**${"  \n".repeat(3)}_something_`);
+    expect(resDefaultMaxNewLines).toBe(`**text**${'  \n'.repeat(3)}_something_`);
 
     instance.options.maxConsecutiveNewlines = 5;
     const res5MaxNewLines = translate(html);
-    expect(res5MaxNewLines).toBe(`**text**${"  \n".repeat(5)}_something_`);
+    expect(res5MaxNewLines).toBe(`**text**${'  \n'.repeat(5)}_something_`);
 
     instance.options.maxConsecutiveNewlines = 10;
     const res10MaxNewLines = translate(html);
-    expect(res10MaxNewLines).toBe(`**text**${"  \n".repeat(10)}_something_`);
+    expect(res10MaxNewLines).toBe(`**text**${'  \n'.repeat(10)}_something_`);
 
     instance.options.maxConsecutiveNewlines = originalMaxConsecutiveNewlines;
   });
@@ -199,13 +201,13 @@ text`);
     expect(resEscapedQuote).toBe("text  \n\\> text  \n\\> more text");
 
     // No escape for +
-    instance.options.lineStartEscape = [/^(\s*?)((?:[=>-])|(?:#{1,6}\s))|(?:(\d+)(\.\s))/gm, "$1$3\\$2$4"];
+    instance.options.lineStartEscape = [/^(\s*?)((?:[=>-])|(?:#{1,6}\s))|(?:(\d+)(\.\s))/gm, '$1$3\\$2$4'];
 
     const resNotEscapedPlus = translate(`<p>text<br>+ text<br>+ more text</p>`);
     expect(resNotEscapedPlus).toBe("text  \n+ text  \n+ more text");
 
     // No escape also for >
-    instance.options.lineStartEscape = [/^(\s*?)((?:#{1,6}\s))|(?:(\d+)(\.\s))/gm, "$1$3\\$2$4"];
+    instance.options.lineStartEscape = [/^(\s*?)((?:#{1,6}\s))|(?:(\d+)(\.\s))/gm, '$1$3\\$2$4'];
 
     const resNotEscapedQuote = translate(`<p>text<br>> text<br>> more text</p>`);
     expect(resNotEscapedQuote).toBe("text  \n> text  \n> more text");
@@ -220,7 +222,7 @@ text`);
     expect(resEscapedStar).toBe("**text\\*\\*text**");
 
     // No escape for star
-    instance.options.globalEscape = [/[_~\[\]]/gm, "\\$&"];
+    instance.options.globalEscape = [ /[_~\[\]]/gm, '\\$&' ];
 
     const resNotEscapedStar = translate(`<i>text**text</i>`);
     expect(resNotEscapedStar).toBe("_text**text_");
@@ -229,7 +231,7 @@ text`);
     expect(resEscapedBrackets).toBe("# title \\[more words\\]");
 
     // No escape also for brackets
-    instance.options.globalEscape = [/[_~]/gm, "\\$&"];
+    instance.options.globalEscape = [ /[_~]/gm, '\\$&' ];
     const resNotEscapedBrackets = translate(`<h1>title [more words]</h1>`);
     expect(resNotEscapedBrackets).toBe("# title [more words]");
 
@@ -240,11 +242,11 @@ text`);
     const originalReplace = instance.options.textReplace;
 
     instance.options.textReplace = [[/abc/g, "xyz"]];
-    const replaced = translate("<h1>hello abc</h1>");
+    const replaced = translate('<h1>hello abc</h1>');
     expect(replaced).toBe(`# hello xyz`);
 
     instance.options.textReplace = [[/hello/g, "X"]];
-    const replaced2 = translate("<h1>hello abc</h1>");
+    const replaced2 = translate('<h1>hello abc</h1>');
     expect(replaced2).toBe(`# X abc`);
 
     instance.options.textReplace = originalReplace;
@@ -269,7 +271,7 @@ text`);
   test(`useLinkReferenceDefinitions`, () => {
     const originalUseLinkReferenceDefinitions = instance.options.useLinkReferenceDefinitions;
 
-    const url = "http://www.github.com/crosstype";
+    const url = 'http://www.github.com/crosstype';
     const html = `Hello:&nbsp;
         <a href="${url}">a<br><br>b<strong>c</strong></a>
         <a>a<strong>b</strong></a> <!-- This node is treated as text due to no href -->
@@ -280,7 +282,9 @@ text`);
 
     instance.options.useLinkReferenceDefinitions = false;
     let res = translate(html);
-    expect(res).toBe(`Hello: [a b**c**](${url}) a**b** [link2](${url}/other) [repeat link](${url}) <${url}> Goodbye!`);
+    expect(res).toBe(
+      `Hello: [a b**c**](${url}) a**b** [link2](${url}/other) [repeat link](${url}) <${url}> Goodbye!`
+    );
 
     instance.options.useLinkReferenceDefinitions = true;
     res = translate(html);
@@ -294,7 +298,7 @@ text`);
   test(`useInlineLinks`, () => {
     const originalUseInlineLinksDefinitions = instance.options.useInlineLinks;
 
-    const url = "http://www.github.com/crosstype";
+    const url = 'http://www.github.com/crosstype';
     const html = `Hello:&nbsp;
         <a href="${url}">${url}</a> <!-- inline link -->&nbsp;
         <a>a<strong>b</strong></a> <!-- This node is treated as text due to no href -->

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -291,31 +291,6 @@ text`);
     instance.options.useLinkReferenceDefinitions = originalUseLinkReferenceDefinitions;
   });
 
-  test(`useLinkReferenceDefinitions`, () => {
-    const originalUseLinkReferenceDefinitions = instance.options.useLinkReferenceDefinitions;
-
-    const url = "http://www.github.com/crosstype";
-    const html = `Hello:&nbsp;
-        <a href="${url}">a<br><br>b<strong>c</strong></a>
-        <a>a<strong>b</strong></a> <!-- This node is treated as text due to no href -->
-        <a href="${url}/other">link2</a>
-        <a href="${url}">repeat link</a>
-        <a href="${url}">${url}</a><!-- inline link -->&nbsp;Goodbye!
-    `;
-
-    instance.options.useLinkReferenceDefinitions = false;
-    let res = translate(html);
-    expect(res).toBe(`Hello: [a b**c**](${url}) a**b** [link2](${url}/other) [repeat link](${url}) <${url}> Goodbye!`);
-
-    instance.options.useLinkReferenceDefinitions = true;
-    res = translate(html);
-    expect(res).toBe(
-      `Hello: [a b**c**][1] a**b** [link2][2] [repeat link][1] <${url}> Goodbye!\n\n[1]: ${url}\n[2]: ${url}/other`
-    );
-
-    instance.options.useLinkReferenceDefinitions = originalUseLinkReferenceDefinitions;
-  });
-
   test(`useInlineLinks`, () => {
     const originalUseInlineLinksDefinitions = instance.options.useInlineLinks;
 


### PR DESCRIPTION
Hello! Mintlify uses `node-html-markdown` to convert to MDX2 syntax instead of Markdown. MDX2 is unique because users can write React code in the Markdown files. Inline links don't work in MDX2 files because the parser thinks they are HTML tags.

This PR adds the option `useInlineLinks` that defaults to true. Passing false disables the inline links and reverts to `[]()` syntax.