### PR TITLE
Extract language from data attribute if code language is not found in…

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -169,7 +169,8 @@ export const defaultTranslators: TranslatorConfigObject = {
 
     /* Handle code block */
     if (codeBlockStyle === 'fenced') {
-      const language = node.getAttribute('class')?.match(/language-(\S+)/)?.[1] || '';
+      const language =
+        node.getAttribute("class")?.match(/language-(\S+)/)?.[1] || node.getAttribute("data-language") || "";
       return {
         noEscape: true,
         prefix: codeFence + language + '\n',

--- a/test/default-tags.test.ts
+++ b/test/default-tags.test.ts
@@ -100,6 +100,13 @@ describe(`Default Tags`, () => {
       expect(res).toBe('```fortran\n' + str + '\n```\n\n```\n' + str + '\n```');
     });
 
+    test(`Data language`, () => {
+      const res = translate(
+        `<pre data-language="jsx"><code data-language="jsx">${str}</code></pre><pre><code>${str}</code></pre>`
+      );
+      expect(res).toBe("```jsx\n" + str + "\n```\n\n```\n" + str + "\n```");
+    });
+
     test(`Indented`, () => {
       const originalCodeFence = instance.options.codeBlockStyle;
       instance.options.codeBlockStyle = 'indented';
@@ -110,6 +117,7 @@ describe(`Default Tags`, () => {
 
       instance.options.codeFence = originalCodeFence;
     });
+
   });
 
   describe(`Lists (ol + li, ul + li)`, () => {


### PR DESCRIPTION
Here is the example that I've tried to parse markdown and extract language names. It only looks for the class attribute there are cases when language is defined inside the data-language.

`<pre data-language="jsx" data-theme="default"><code data-language="jsx" data-theme="default">`
