### PR TITLE
README: Fix strike delimiter comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ export interface NodeHtmlMarkdownOptions {
   strongDelimiter: string,
 
   /**
-   * Strong delimiter
+   * Strike delimiter
    * @default ~~
    */
   strikeDelimiter: string,


### PR DESCRIPTION
Just fixing a simple copy/paste error in the readme

Thanks for all your work on the node-html-markdown library!