### PR TITLE
Fix ReferenceError: process is not defined when in browser

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -225,11 +225,11 @@ export function getChildNodes(node: HtmlNode | Node): (Node | HtmlNode)[] {
 }
 
 export function perfStart(label: string) {
-  if (process.env.LOG_PERF) console.time(label);
+  if (typeof process !== 'undefined' && process?.env?.LOG_PERF) console.time(label);
 }
 
 export function perfStop(label: string) {
-  if (process.env.LOG_PERF) console.timeEnd(label);
+  if (typeof process !== 'undefined' && process?.env?.LOG_PERF) console.timeEnd(label);
 }
 
 // endregion


### PR DESCRIPTION
According to the Readme it should work in the browser. But for me it faild.

I applied a patch to check if process is existing before accessing it.

This lib is cool and excectly what I needed.  There is already another PR (#43) that seems to fix this by changing the build. But its scope is much broader, so I thought I share my changes.